### PR TITLE
Fix warnings from using deprecated Application.loadedLevel

### DIFF
--- a/Assets/UtilityKit/Editor/ConstantsGeneratorKit.cs
+++ b/Assets/UtilityKit/Editor/ConstantsGeneratorKit.cs
@@ -135,10 +135,11 @@ namespace Prime31Editor
 				output += "\n\t\tpublic const int " + TOTAL_SCENES_CONSTANT_NAME + " = " + labelsArray.Length + ";\n\n\n";
 
 				output += "\t\tpublic static int nextSceneIndex()\n";
-				output += "\t\t{\n";
-				output += "\t\t\tif( UnityEngine.Application.loadedLevel + 1 == " + TOTAL_SCENES_CONSTANT_NAME + " )\n";
-				output += "\t\t\t\treturn 0;\n";
-				output += "\t\t\treturn UnityEngine.Application.loadedLevel + 1;\n";
+                output += "\t\t{\n";
+                output += "\t\t\tvar currentSceneIndex = UnityEngine.SceneManagement.SceneManager.GetActiveScene().buildIndex;\n";
+                output += "\t\t\tif( currentSceneIndex + 1 == " + TOTAL_SCENES_CONSTANT_NAME + " )\n";
+                output += "\t\t\t\treturn 0;\n";
+                output += "\t\t\treturn currentSceneIndex + 1;\n";
 				output += "\t\t}\n";
 			}
 


### PR DESCRIPTION
This removes the warnings due to using deprecated Application.loadedLevel by using the new SceneManagement library.
